### PR TITLE
Could not find lint-gradle-api.jar (com.android.tools.lint:lint-gradle-api:26.1.2)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,11 +1,11 @@
 
 buildscript {
     repositories {
-        jcenter()
         maven {
             url 'https://maven.google.com/'
             name 'Google'
         }
+        jcenter()
     }
 
     dependencies {


### PR DESCRIPTION
Changed to the recommended order for repositories.